### PR TITLE
synchronize book example with code.

### DIFF
--- a/book/ch06.rst
+++ b/book/ch06.rst
@@ -217,10 +217,10 @@ comparing different feature-outcome relationships.
 When working with large corpora, constructing a single list
 that contains the features of every instance can use up a large
 amount of memory.  In these cases, use the function
-``nltk.classify.apply_features``, which returns an object that acts
+``nltk.classify.util.apply_features``, which returns an object that acts
 like a list but does not store all the feature sets in memory:
 
-    >>> from nltk.classify import apply_features
+    >>> from nltk.classify.util import apply_features
     >>> train_set = apply_features(gender_features, names[500:])
     >>> test_set = apply_features(gender_features, names[:500])
 


### PR DESCRIPTION
an example in the NLTK book no longer works since apply_features is no longer imported into nltk.classify. See comment below for a fix in the Python code (rather than the book).
