### PR TITLE
Fix reference to nonexistant method in Chapter 5

### DIFF
--- a/book/ch05.rst
+++ b/book/ch05.rst
@@ -75,7 +75,7 @@ Here we see that `and`:lx: is ``CC``, a coordinating conjunction;
 .. note::
    |NLTK| provides documentation for each tag, which can be queried using
    the tag, e.g. ``nltk.help.upenn_tagset('RB')``, or a regular
-   expression, e.g. ``nltk.help.upenn_brown_tagset('NN.*')``.
+   expression, e.g. ``nltk.help.upenn_tagset('NN.*')``.
    Some corpora have README files with tagset documentation,
    see ``nltk.corpus.???.readme()``, substituting in the name
    of the corpus.


### PR DESCRIPTION
Chapter 5 contained a refence to a nonexistant method:
`...or a regular expression, e.g. ``nltk.help.upenn_brown_tagset('NN.*')``.`
Changed to `nltk.help.upenn_tagset('NN.*')`.
