### PR TITLE
Typo

### DIFF
--- a/book/ch03.rst
+++ b/book/ch03.rst
@@ -1,4 +1,4 @@
-:.. -*- mode: rst -*-
+.. -*- mode: rst -*-
 .. include:: ../definitions.rst
 .. include:: regexp-defns.rst
 


### PR DESCRIPTION
I assume the colon is superfluous - and caused the erroneous rendering at the top of [chapter 3](http://www.nltk.org/book/ch03.html)