### PR TITLE
Unnecessary leading space leads to incorrectly generated HTML

### DIFF
--- a/book/ch03.rst
+++ b/book/ch03.rst
@@ -979,7 +979,7 @@ Unicode character will be dislayed on the screen as the glyph
 In Python 3, source code is encoded using UTF-8 by default, and you can
 include Unicode characters in strings if you are using IDLE or another program editor
 that supports Unicode.
- Arbitrary Unicode characters can be included using the
+Arbitrary Unicode characters can be included using the
 ``\u``\ *XXXX* escape sequence.
 We find the integer ordinal of a character using ``ord()``. For example:
 


### PR DESCRIPTION
http://www.nltk.org/book/ch03.html:

```
System Message: ERROR/3 (ch03.rst2, line 982)
Unexpected indentation.

    Arbitrary Unicode characters can be included using the

System Message: WARNING/2 (ch03.rst2, line 983)
Block quote ends without a blank line; unexpected unindent.

\uXXXX escape sequence.
```