### PR TITLE
Fixed a broken reference to a Chinese character

### DIFF
--- a/definitions.rst
+++ b/definitions.rst
@@ -180,7 +180,7 @@
   
 .. Chinese
 .. |ai4| unicode:: U+7231 .. zh ai (love)
-.. |guo3| unicode:: U+56FD .. zh guo (country)
+.. |guo2| unicode:: U+56FD .. zh guo (country)
 .. |ren2| unicode:: U+4EBA .. zh ren (person)
   
 .. URLs


### PR DESCRIPTION
Chinese for country is *guo2*. guo2 is also referenced from ch03.rst, but, as there was no such definition, it was causing an error in generated HTML:

```
Docutils System Messages

System Message: ERROR/3 (ch03.rst2, line 1976); backlink
Undefined substitution referenced: "guo2".

System Message: ERROR/3 (ch03.rst2, line 1976); backlink
Undefined substitution referenced: "guo2".

System Message: ERROR/3 (ch03.rst2, line 1976); backlink
Undefined substitution referenced: "guo2".
```
