### PR TITLE
Preface: Fix mangled quotes and double quotes in 'Using Code Examples'.

### DIFF
--- a/book/ch00.rst
+++ b/book/ch00.rst
@@ -524,16 +524,16 @@ Using Code Examples
 
 This book is here to help you get your job done. In general, you may use the code in
 this book in your programs and documentation. You do not need to contact us for
-permission unless youÕre reproducing a significant portion of the code. For example,
+permission unless you're reproducing a significant portion of the code. For example,
 writing a program that uses several chunks of code from this book does not require
-permission. Selling or distributing a CD-ROM of examples from OÕReilly books does
+permission. Selling or distributing a CD-ROM of examples from O'Reilly books does
 require permission. Answering a question by citing this book and quoting example
 code does not require permission. Incorporating a significant amount of example code
-from this book into your productÕs documentation does require permission.
+from this book into your product's documentation does require permission.
 
 We appreciate, but do not require, attribution. An attribution usually includes the title,
-author, publisher, and ISBN. For example: ÒNatural Language Processing with Python,
-by Steven Bird, Ewan Klein, and Edward Loper.  O'Reilly Media, 978-0-596-51649-9.Ó
+author, publisher, and ISBN. For example: "Natural Language Processing with Python,
+by Steven Bird, Ewan Klein, and Edward Loper.  O'Reilly Media, 978-0-596-51649-9."
 If you feel your use of code examples falls outside fair use or the permission given above,
 feel free to contact us at *permissions@oreilly.com*.
 


### PR DESCRIPTION
It looks like the mangled quotes were hardcoded in the text.

Fixes #171.