### PR TITLE
Change the brill tagger demo in chapter 5

### DIFF
--- a/book/ch05.rst
+++ b/book/ch05.rst
@@ -262,7 +262,7 @@ For example, fig-tag-indian_ shows data accessed using
 
    POS-Tagged Data from Four Indian Languages: Bangla, Hindi, Marathi, and Telugu
 
-..    इराक_NNP के_PREP विदेश_NNC मंत्री_NN ने_PREP अमरीका_NNP के_PREP उस_PRP प्रस्ताव_NN का_PREP मजाक_NVB उड़ाया_VFM है_VAUX ...
+..    इराक_NNP के_PREP विदेश_NNC मंत्री_NN ने_PREP अमरीका_NNP के_PREP उस_PRP प्रस्ताव_NN का_PREP मजाक_NVB उड़ाया_VFM है_VAUX ...
 
 If the corpus is also segmented into sentences, it will have
 a ``tagged_sents()`` method that divides up the tagged words into
@@ -1723,7 +1723,8 @@ code-brill-demo_ demonstrates |NLTK|\ 's Brill tagger.
              correct cases it breaks; apart from training a tagger, the
              demonstration displays residual errors.
 
-    >>> nltk.tag.brill.demo()
+    >>> from nltk.tbl import demo as brill_demo
+    >>> brill_demo.demo()
     Training Brill tagger on 80 sentences...
     Finding initial useful rules...
         Found 6555 useful rules.


### PR DESCRIPTION
Brill tagger demo has been moved. The demo imports should be changed appropriately.

c.f. nltk/nltk#1828
