### PR TITLE
Update ch03.rst

### DIFF
--- a/book/ch03.rst
+++ b/book/ch03.rst
@@ -84,7 +84,7 @@ Text number 2554 is an English translation of *Crime and Punishment*,
 and we can access it as follows.
 
     >>> from urllib import request
-    >>> url = "http://www.gutenberg.org/files/2554/2554.txt"
+    >>> url = "http://www.gutenberg.org/files/2554/2554-0.txt"
     >>> response = request.urlopen(url)
     >>> raw = response.read().decode('utf8')
     >>> type(raw)


### PR DESCRIPTION
The URL of an English translation of Crime and Punishment changed the following URL : 
- http://www.gutenberg.org/files/2554/2554-0.txt 