### PR TITLE
Change first function to match second function

### DIFF
--- a/book/ch02.rst
+++ b/book/ch02.rst
@@ -992,7 +992,7 @@ function.  Here's the function we saw in sec-computing-with-language-texts-and-w
 
     >>> from __future__ import division
     >>> def lexical_diversity(text):
-    ...     return len(text) / len(set(text))
+    ...     return len(set(text)) / len(text)
 
 We use the keyword ``return`` to indicate the value that is
 produced as output by the function.  In the above example,


### PR DESCRIPTION
The two functions for diversity were not equivalent.