### PR TITLE
Fixed tags for the graphical condordance

### DIFF
--- a/book/ch05.rst
+++ b/book/ch05.rst
@@ -566,7 +566,7 @@ the distinctions between the tags.
     >>> data = nltk.ConditionalFreqDist((word.lower(), tag)
     ...                                 for (word, tag) in brown_news_tagged)
     >>> for word in sorted(data.conditions()):
-    ...     if len(data[word]) > 3:
+    ...     if len(data[word]) >= 3:
     ...         tags = [tag for (tag, _) in data[word].most_common()]
     ...         print(word, ' '.join(tags))
     ...


### PR DESCRIPTION
The tags for the graphical concordance example were incorrect.