### PR TITLE
Update ch05.rst

### DIFF
--- a/book/ch05.rst
+++ b/book/ch05.rst
@@ -418,7 +418,10 @@ To clarify the distinction between ``VBD`` (past tense) and ``VBN``
 (past participle), let's find words which can be both ``VBD`` and
 ``VBN``, and see some surrounding text:
 
-    >>> [w for w in cfd1.conditions() if 'VBD' in cfd1[w] and 'VBN' in cfd1[w]]
+    >>> wsj1 = nltk.corpus.treebank.tagged_words()
+    >>> word_tag_fd = nltk.FreqDist(wsj1)
+    >>> cfd3 = nltk.ConditionalFreqDist(wsj1)
+    >>> [w for w in cfd3.conditions() if 'VBD' in cfd3[w] and 'VBN' in cfd3[w]]
     ['Asked', 'accelerated', 'accepted', 'accused', 'acquired', 'added', 'adopted', ...]
     >>> idx1 = wsj.index(('kicked', 'VBD'))
     >>> wsj[idx1-4:idx1+1]


### PR DESCRIPTION
While studying the NLTK book, the code in __line 422__ procuded as an output an empty list `[]`.

In my limited understanding, this is because in __line 388__ `wsj` is defined with universal tagset `wsj = nltk.corpus.treebank.tagged_words(tagset='universal')`, while in __line 422__ is searching for the default tagset format.

I added a `cfd3` with the default tagset and the code worked.

I am sorry in advance if I misunderstood something!