### PR TITLE
Correct publication year

### DIFF
--- a/book/ch02.rst
+++ b/book/ch02.rst
@@ -2053,7 +2053,7 @@ Exercises
    Rank the pairs in order of decreasing similarity.
    How close is your ranking to the order given here,
    an order that was established experimentally
-   by [MillerCharles1998]_:
+   by [MillerCharles1991]_:
    car-automobile, gem-jewel, journey-voyage, boy-lad,
    coast-shore, asylum-madhouse, magician-wizard, midday-noon,
    furnace-stove, food-fruit, bird-cock, bird-crane, tool-implement,

--- a/refs.bib
+++ b/refs.bib
@@ -817,13 +817,13 @@ st},
   year = 	 2003,
   address = 	 {Boston}}
 
-@Article{MillerCharles1998,
+@Article{MillerCharles1991,
   author =	 {George Miller and Walter Charles},
   title =	 {Contextual correlates of semantic similarity},
   journal =	 {Language and Cognitive Processes},
   volume =	 {6},
   pages =	 {1--28},
-  year =	 1998
+  year =	 1991
 }
 
 @book{Mitkov02handbook,


### PR DESCRIPTION
"Contextual correlates of semantic similarity" by Miller and Charles was published in 1991, not 1998.

Source: https://www.tandfonline.com/doi/abs/10.1080/01690969108406936