### PR TITLE
Remove exercise about `cmp` in chapter 4

### DIFF
--- a/book/ch04.rst
+++ b/book/ch04.rst
@@ -2606,10 +2606,6 @@ Exercises
    list ``['NLP', 'is', 'fun', '!']``.  Now do the same transformation
    using tuple assignment.
 
-#. |easy| Read about the built-in comparison function ``cmp``, by
-   typing ``help(cmp)``.  How does it differ in behavior from
-   the comparison operators?
-
 #. |easy| Does the method for creating a sliding window of n-grams
    behave correctly for the two limiting cases: `n`:math: = 1, and `n`:math: = ``len(sent)``?
 


### PR DESCRIPTION
The Python 2 function `cmp` has been removed Python 3.
From https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
> The `cmp()` function should be treated as gone, and the `__cmp__()` special method is no longer supported.

This is related to #201