### PR TITLE
Update exercise to avoid `cmp` function

### DIFF
--- a/book/ch04.rst
+++ b/book/ch04.rst
@@ -2631,8 +2631,9 @@ Exercises
 
    #) do this task using regular expression substitutions
 
-#. |easy| Write a program to sort words by length.  Define a helper function
-   ``cmp_len`` which uses the ``cmp`` comparison function on word lengths.
+#. |easy| Write a program to sort words by length. Can you do it
+   in one line using ``list.sort()`` with the proper ``key`` argument?
+   ```https://docs.python.org/3/library/stdtypes.html#list.sort```
 
 #. |soso| Create a list of words and store it in a variable ``sent1``.
    Now assign ``sent2 = sent1``.  Modify one of the items in ``sent1``


### PR DESCRIPTION
The `cmp` function has been removed in Python 3.

I believe the original intention of the exercise is to learn sorting with non-alphabetic orders. The exercise is rephrased to achieve the same result without `cmp`. A solution would be `words.sort(key=len)`, where `words` is a list of strings.

The issue has been mentioned here: https://github.com/nltk/nltk_book/pull/261#issuecomment-1412303946